### PR TITLE
Fix the time of Graduation Days in the calendar event links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Don't forget to watch the livestream!
 - ⏰ 9:00am PT | 16:00 GMT | 21:30 IST
 - 📍 Follow the [GitHub Education Twitch Channel](https://twitch.tv/githubeducation) for notifications.
 - 📎Add the event to your calender:
-  - [Google Calendar](https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20220611T200000Z%2F20220611T220000Z&details=&location=https%3A%2F%2Fwww.twitch.tv%2Fgithubeducation&text=%F0%9F%8E%89%F0%9F%8E%8A%20GitHub%20Graduation%202022%20%F0%9F%8E%89%F0%9F%8E%8A)
-  - [Outlook Calendar](https://outlook.live.com/calendar/0/deeplink/compose?allday=false&body=&enddt=2022-06-11T22%3A00%3A00%2B00%3A00&location=https%3A%2F%2Fwww.twitch.tv%2Fgithubeducation&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2022-06-11T20%3A00%3A00%2B00%3A00&subject=%F0%9F%8E%89%F0%9F%8E%8A%20GitHub%20Graduation%202022%20%F0%9F%8E%89%F0%9F%8E%8A)
-  - [Yahoo Calendar](https://calendar.yahoo.com/?desc=&dur=&et=20220611T220000Z&in_loc=https%3A%2F%2Fwww.twitch.tv%2Fgithubeducation&st=20220611T200000Z&title=%F0%9F%8E%89%F0%9F%8E%8A%20GitHub%20Graduation%202022%20%F0%9F%8E%89%F0%9F%8E%8A&v=60)
+  - [Google Calendar](https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20220611T160000Z%2F20220611T180000Z&details=&location=https%3A%2F%2Fwww.twitch.tv%2Fgithubeducation&text=%F0%9F%8E%89%F0%9F%8E%8A%20GitHub%20Graduation%202022%20%F0%9F%8E%89%F0%9F%8E%8A)
+  - [Outlook Calendar](https://outlook.live.com/calendar/0/deeplink/compose?allday=false&body=&enddt=2022-06-11T18%3A00%3A00%2B00%3A00&location=https%3A%2F%2Fwww.twitch.tv%2Fgithubeducation&path=%2Fcalendar%2Faction%2Fcompose&rru=addevent&startdt=2022-06-11T16%3A00%3A00%2B00%3A00&subject=%F0%9F%8E%89%F0%9F%8E%8A%20GitHub%20Graduation%202022%20%F0%9F%8E%89%F0%9F%8E%8A)
+  - [Yahoo Calendar](https://calendar.yahoo.com/?desc=&dur=&et=20220611T180000Z&in_loc=https%3A%2F%2Fwww.twitch.tv%2Fgithubeducation&st=20220611T160000Z&title=%F0%9F%8E%89%F0%9F%8E%8A%20GitHub%20Graduation%202022%20%F0%9F%8E%89%F0%9F%8E%8A&v=60)
 
 
 Questions about GitHub Graduation? Ask in the [GitHub Community Discussions](https://github.com/orgs/github-community/discussions/categories/github-education).


### PR DESCRIPTION
⚠Note: this is not a "add me" PR.

According to the current README.md, the time of Graduation Day is:

> :alarm_clock: 9:00am PT | **16:00 GMT** | 21:30 IST

On the other hand, this conflicts with the time on the three links in the calendar. At least on my end, the event is registered as starting at **20:00 GMT**, 4 hours late.

This PR fixes the link URLs based on the time 16:00 GMT.

## Related PR

* The time in #517 should be still incorrect if this PR is correct

## Detailed comments

* It seems that 087d0f4df3ce1a85b56ec386081aea9ffcad3265 introduced the time change when it increased the number of links to three, but I could not tell if this was intentional or not

* I worry that correcting the misinformation may not be possible
    * Clicking on the link makes a complete copy of data to our calendar
* On a personal note, I learned the importance of DRY