### PR TITLE
Translation link error fixed for Bangla

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 * [ไทย](./translations/README.th.md)
 * [Arabic](./translations/README.ar.md)
 * [Malay](./translations/README.may.md)
-* [Bangla](./translations/README.bn.md)
+* [Bangla](./translations/README.bn_bd.md)
 
 *Read the instructions in your language or [contribute a translation](translations/README.md)!*
 


### PR DESCRIPTION
This error is causing from wrong file name in link. This error came from latest PR of enchantment.