### PR TITLE
Update README.pt-br.md

### DIFF
--- a/translations/README.pt-br.md
+++ b/translations/README.pt-br.md
@@ -70,7 +70,6 @@ name: NOME-COMPLETO-OU-APELIDO # Até 28 caracteres
 institution: NOME-INSTITUIÇÃO 🚩 # Até 58 caracteres
 quote: SUA-FRASE # Até 100 caracteres, evite usar aspas(")para garantir que o formato permaneça o mesmo. 
 github_user: SEU-NOME-DE-USUARIO-GITBHUB
-
 ---
 ```
 

--- a/translations/README.pt-br.md
+++ b/translations/README.pt-br.md
@@ -74,7 +74,7 @@ github_user: SEU-NOME-DE-USUARIO-GITBHUB
 ```
 
 
-_Não use caracteres especiais do modelo acima._
+_Não use caracteres especiais no modelo acima._
 
 #### E por último, envie o seu pull request
 


### PR DESCRIPTION
- Removed extra space from PT-BR template model. 
- Fixed grammatical issue for translation of phrase `"Do not use special characters in the template above."`
   - `in the` is better translated to the preposition `no` instead of `do`
   -  note: `do` would be a better choice if the term were `of the`